### PR TITLE
[Feat] Modal, Input, Dropdown, Button atom 생성 (#6)

### DIFF
--- a/src/atoms/Button/Button.tsx
+++ b/src/atoms/Button/Button.tsx
@@ -1,5 +1,6 @@
+/** @jsxImportSource @emotion/react */
 import React from 'react';
-import styled from '@emotion/styled';
+import { css } from '@emotion/react';
 
 export interface ButtonProps {
   onClick: () => void;
@@ -7,14 +8,13 @@ export interface ButtonProps {
   disabled?: boolean;
 }
 
-const StyledButton = styled.button`
+const ButtonStyle = css` // 임시
   width: 26px;
 `;
 
-export default function Button({ onClick, children, disabled = false }: ButtonProps) {
+export default function Button({onClick, disabled=false} : ButtonProps){
   return (
-    <StyledButton onClick={onClick} disabled={disabled}>
-      {children}
-    </StyledButton>
+    <button css={ButtonStyle} onClick={onClick} disabled={disabled}>
+    </button>
   );
 };

--- a/src/atoms/Button/Button.tsx
+++ b/src/atoms/Button/Button.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+export interface ButtonProps {
+  onClick: () => void;
+  children?: React.ReactNode;
+  disabled?: boolean;
+}
+
+const StyledButton = styled.button`
+  width: 26px;
+`;
+
+export default function Button({ onClick, children, disabled = false }: ButtonProps) {
+  return (
+    <StyledButton onClick={onClick} disabled={disabled}>
+      {children}
+    </StyledButton>
+  );
+};

--- a/src/atoms/Dropdown/Dropdown.tsx
+++ b/src/atoms/Dropdown/Dropdown.tsx
@@ -1,6 +1,6 @@
+/** @jsxImportSource @emotion/react */
 import React from 'react';
 import { css } from '@emotion/react';
-import styled from '@emotion/styled';
 
 export interface DropdownProps {
     onChange: (event: React.ChangeEvent<HTMLSelectElement>) => void;
@@ -10,25 +10,26 @@ export interface DropdownProps {
     disabled?: boolean;
 }
 
-const StyledDropdown = styled.select`
+const DropdownStyle = css` // 임시
   width: 26px;
 `;
 
 export default function Dropdown({ onChange, value, options, placeholder = '', disabled = false }: DropdownProps) {
     return(
-        <StyledDropdown
+        <select
+             css={DropdownStyle}
              onChange={onChange}
              value={value}
              disabled={disabled}
          >
-            <option value="" disabled>
-                {placeholder}
-            </option>
-            {options.map(option => (
-                <option key={option.value} value={option.value}>
-                    {option.label}
-                </option>
-            ))}
-        </StyledDropdown>
-    );
-}
+        <option value="" disabled>
+        {placeholder}
+        </option>
+        {options.map(option => (
+        <option key={option.value} value={option.value}>
+        {option.label}
+        </option>
+        ))}
+        </select>
+    )
+    }

--- a/src/atoms/Dropdown/Dropdown.tsx
+++ b/src/atoms/Dropdown/Dropdown.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export interface DropdownProps {
+    onChange: (event: React.ChangeEvent<HTMLSelectElement>) => void;
+    value: string;
+    options: {value: string, label: string}[];
+    placeholder?: string;
+    disabled?: boolean;
+}
+
+const StyledDropdown = styled.select`
+  width: 26px;
+`;
+
+export default function Dropdown({ onChange, value, options, placeholder = '', disabled = false }: DropdownProps) {
+    return(
+        <StyledDropdown
+             onChange={onChange}
+             value={value}
+             disabled={disabled}
+         >
+            <option value="" disabled>
+                {placeholder}
+            </option>
+            {options.map(option => (
+                <option key={option.value} value={option.value}>
+                    {option.label}
+                </option>
+            ))}
+        </StyledDropdown>
+    );
+}

--- a/src/atoms/Input/Input.tsx
+++ b/src/atoms/Input/Input.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { css} from '@emotion/react';
+import styled from '@emotion/styled'
+
+export interface InputProps {
+    onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+    value: string;
+    placeholder?: string;
+    disabled?: boolean;
+}
+
+const StyledInput = styled.input`
+  width: 26px;
+`;
+
+export default function TextInput({ onChange, value, placeholder = '', disabled = false }: InputProps) {
+    return (
+        <StyledInput
+            onChange={onChange}
+            value={value}
+            placeholder={placeholder}
+            disabled={disabled}
+            type="text"
+        />
+    );
+}

--- a/src/atoms/Input/Input.tsx
+++ b/src/atoms/Input/Input.tsx
@@ -1,26 +1,28 @@
+/** @jsxImportSource @emotion/react */
 import React from 'react';
-import { css} from '@emotion/react';
-import styled from '@emotion/styled'
+import { css } from '@emotion/react';
 
 export interface InputProps {
     onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-    value: string;
-    placeholder?: string;
-    disabled?: boolean;
+    value:string;
+    placeholder?:string;
+    disabled?:boolean;
 }
 
-const StyledInput = styled.input`
+const InputStyle = css` //임시
   width: 26px;
 `;
 
+
 export default function TextInput({ onChange, value, placeholder = '', disabled = false }: InputProps) {
-    return (
-        <StyledInput
+    return(
+        <input
+            css={InputStyle}
             onChange={onChange}
             value={value}
             placeholder={placeholder}
             disabled={disabled}
             type="text"
-        />
-    );
+        />     
+    )
 }

--- a/src/atoms/Modal/Modal.tsx
+++ b/src/atoms/Modal/Modal.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+const ModalBackground = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+`;
+
+const ModalContent = styled.div`
+  background-color: #ffffff;
+  width: 80%;
+  max-width: 400px;
+  padding: 20px;
+  border-radius: 4px;
+`;
+
+export default function Modal({ open, onClose, children }: ModalProps) {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <ModalBackground onClick={onClose}>
+      <ModalContent onClick={(e) => e.stopPropagation()}>
+        {children}
+      </ModalContent>
+    </ModalBackground>
+  );
+}

--- a/src/atoms/Modal/Modal.tsx
+++ b/src/atoms/Modal/Modal.tsx
@@ -1,5 +1,6 @@
+/** @jsxImportSource @emotion/react */
 import React from 'react';
-import styled from '@emotion/styled';
+import { css } from '@emotion/react';
 
 interface ModalProps {
   open: boolean;
@@ -7,7 +8,7 @@ interface ModalProps {
   children: React.ReactNode;
 }
 
-const ModalBackground = styled.div`
+const modalBackgroundStyle = css`
   position: fixed;
   top: 0;
   left: 0;
@@ -20,7 +21,7 @@ const ModalBackground = styled.div`
   z-index: 1000;
 `;
 
-const ModalContent = styled.div`
+const modalContentStyle = css`
   background-color: #ffffff;
   width: 80%;
   max-width: 400px;
@@ -33,11 +34,11 @@ export default function Modal({ open, onClose, children }: ModalProps) {
     return null;
   }
 
-  return (
-    <ModalBackground onClick={onClose}>
-      <ModalContent onClick={(e) => e.stopPropagation()}>
+  return(
+    <div css={modalBackgroundStyle} onClick={onClose}>
+      <div css={modalContentStyle} onClick={(e) => e.stopPropagation()}>
         {children}
-      </ModalContent>
-    </ModalBackground>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
### 개요
컴포넌트에서 재사용할 요소들을 atom으로 만들었습니다.
또한 기존 PR은 closed 해놓았습니다.

**atom**
1. modal
2. input
3. dropdown
4. button

- 추가적으로 마스터 브랜치를 받아오면서 emotion 코드가 작동하지 않아 기존 코드에서 css 부분은 styled 코드로 약간 바꿨습니다. 이유를 아신다면 댓글 달아주시면 감사하겠습니다.